### PR TITLE
Optimise final exponentiations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
-curv = { git = "https://github.com/ZenGo-X/curv", tag = "v0.5.2"}
+curv = { git = "https://github.com/ZenGo-X/curv", branch = "pairing"}
 zeroize = "0.10"
 rand = "0.7.3"
 pairing-plus = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ serde_derive = "1.0"
 curv = { git = "https://github.com/ZenGo-X/curv", tag = "v0.5.2"}
 zeroize = "0.10"
 rand = "0.7.3"
+pairing-plus = "0.17"
+ff = "0.4.0"
 
 [lib]
 crate-type = ["lib"]

--- a/src/threshold_bls/party_i.rs
+++ b/src/threshold_bls/party_i.rs
@@ -1,7 +1,6 @@
 use crate::Error;
 
 use curv::arithmetic::traits::*;
-
 use curv::elliptic::curves::traits::*;
 
 use curv::cryptographic_primitives::commitments::hash_commitment::HashCommitment;
@@ -13,12 +12,13 @@ use curv::BigInt;
 use crate::basic_bls::BLSSignature;
 use crate::threshold_bls::utilities::{ECDDHProof, ECDDHStatement, ECDDHWitness};
 use curv::cryptographic_primitives::secret_sharing::feldman_vss::ShamirSecretSharing;
-use curv::elliptic::curves::bls12_381::g1::FE as FE1;
-use curv::elliptic::curves::bls12_381::g1::GE as GE1;
-use curv::elliptic::curves::bls12_381::g2::FE as FE2;
-use curv::elliptic::curves::bls12_381::g2::GE as GE2;
+use curv::elliptic::curves::bls12_381::g1::{FE as FE1, GE as GE1};
+use curv::elliptic::curves::bls12_381::g2::{FE as FE2, GE as GE2};
 use curv::elliptic::curves::bls12_381::Pair;
 use serde::{Deserialize, Serialize};
+
+use ff::Field;
+use pairing_plus::bls12_381::Fq12;
 
 const SECURITY: usize = 256;
 
@@ -241,34 +241,12 @@ impl SharedKeys {
 
         let partial_sigs_verify = (0..vk_vec.len())
             .map(|i| {
-                use pairing_plus::CurveAffine;
-                use pairing_plus::Engine;
-
-                let mut negate_H_x = H_x.get_element();
-                negate_H_x.negate();
-                // pairing_plus::bls12_381::Bls12::pairing_product(
-                //     negate_H_x,
-                //     vk_vec[i].get_element(),
-                //     partial_sigs_vec[i].sigma_i.get_element(),
-                //     GE2::generator().get_element(),
-                // );
-                let product = pairing_plus::bls12_381::Bls12::final_exponentiation(
-                    &pairing_plus::bls12_381::Bls12::miller_loop(
-                        [
-                            (
-                                &(negate_H_x.prepare()),
-                                &(vk_vec[i].get_element().prepare()),
-                            ),
-                            (
-                                &(partial_sigs_vec[i].sigma_i.get_element().prepare()),
-                                &(GE2::generator().get_element().prepare()),
-                            ),
-                        ]
-                        .iter(),
-                    ),
+                let product = Pair::efficient_pairing_mul(
+                    &(-H_x),
+                    &vk_vec[i],
+                    &partial_sigs_vec[i].sigma_i,
+                    &GE2::generator(),
                 );
-                // let left = Pair::compute_pairing(&H_x, &vk_vec[i]);
-                // let right = Pair::compute_pairing(&partial_sigs_vec[i].sigma_i, &GE2::generator());
                 let delta = ECDDHStatement {
                     g1: H_x.clone(),
                     h1: partial_sigs_vec[i].sigma_i.clone(),
@@ -276,9 +254,7 @@ impl SharedKeys {
                     h2: vk_vec[i],
                 };
 
-                use ff::Field;
-                partial_sigs_vec[i].ddh_proof.verify(&delta)
-                    && product == Some(pairing_plus::bls12_381::Fq12::one())
+                partial_sigs_vec[i].ddh_proof.verify(&delta) && product.e == Fq12::one()
             })
             .all(|x| x);
         if partial_sigs_verify == false {


### PR DESCRIPTION
In signing protocol there's a check that `e(g1, g2) == e(g3, g4)` which involves two pairings. PR a bit optimises it by using this trick: `e(g1, g2) == e(g3, g4) <=> (e'(-g1,g2) e'(g3,g4))^x == 1` (where e'(...) is a pairing without final exponentiation, and ...^x is the final exponentiation).

Benchmarks detected performance improvement (17% for `sign t=1 n=2` and 22% for `sign t=2 n=3`)