### PR TITLE
Aggregated verification of bls

### DIFF
--- a/src/aggregated_bls/party_i.rs
+++ b/src/aggregated_bls/party_i.rs
@@ -1,17 +1,22 @@
-use crate::aggregated_bls::h1;
-use crate::basic_bls::BLSSignature;
+use std::collections::HashSet;
+
 use curv::arithmetic::traits::Modulo;
 use curv::elliptic::curves::bls12_381::g1::FE as FE1;
 use curv::elliptic::curves::bls12_381::g1::GE as GE1;
 use curv::elliptic::curves::bls12_381::g2::FE as FE2;
 use curv::elliptic::curves::bls12_381::g2::GE as GE2;
+use curv::elliptic::curves::bls12_381::Pair;
 use curv::elliptic::curves::traits::ECPoint;
 use curv::elliptic::curves::traits::ECScalar;
 use curv::BigInt;
+use pairing_plus::bls12_381::Bls12;
+use pairing_plus::{CurveAffine, Engine};
+
+use crate::aggregated_bls::h1;
+use crate::basic_bls::BLSSignature;
 
 /// This is an implementation of BDN18 [https://eprint.iacr.org/2018/483.pdf]
 /// protocol 3.1 (MSP): pairing-based multi-signature with public-key aggregation
-
 #[derive(Copy, PartialEq, Clone, Debug)]
 pub struct Keys {
     pub sk_i: FE2,
@@ -24,7 +29,7 @@ pub type SIG = GE1;
 
 impl Keys {
     pub fn new(index: usize) -> Self {
-        let u: FE2 = ECScalar::new_random();
+        let u = ECScalar::new_random();
         let y = &ECPoint::generator() * &u;
 
         Keys {
@@ -52,11 +57,41 @@ impl Keys {
 
     pub fn combine_local_signatures(sigs: &[SIG]) -> BLSSignature {
         let (head, tail) = sigs.split_at(1);
-        let sig_sum = tail.iter().fold(head[0], |x, acc| x + acc);
+        let sig_sum = tail.iter().fold(head[0], |acc, x| acc + x);
         BLSSignature { sigma: sig_sum }
     }
 
     pub fn verify(signature: &BLSSignature, message: &[u8], apk: &APK) -> bool {
         signature.verify(message, apk)
+    }
+
+    fn efficient_pairing_loop(vec_g1: &[GE1], vec_g2: &[GE2]) -> Pair {
+        let vec_g1_prep: Vec<_> = vec_g1.iter().map(|x| x.get_element().prepare()).collect();
+        let vec_g2_prep: Vec<_> = vec_g2.iter().map(|x| x.get_element().prepare()).collect();
+        let vec: Vec<_> = vec_g1_prep.iter().zip(vec_g2_prep.iter()).collect();
+        Pair {
+            e: Bls12::final_exponentiation(&Bls12::miller_loop(vec.iter())).unwrap(),
+        }
+    }
+
+    pub fn aggregate_bls(sig_vec: &[BLSSignature]) -> BLSSignature {
+        let (head, tail) = sig_vec.split_at(1);
+        BLSSignature {
+            sigma: tail.iter().fold(head[0].sigma, |acc, x| acc + x.sigma),
+        }
+    }
+
+    fn core_aggregate_verify(apk_vec: &[APK], msg_vec: &[&[u8]], sig: &BLSSignature) -> bool {
+        let product_c2 = Keys::efficient_pairing_loop(&[sig.sigma], &[GE2::generator()]);
+        let vec_g1: Vec<GE1> = msg_vec.iter().map(|&x| GE1::hash_to_curve(&x)).collect();
+        let product_c1 = Keys::efficient_pairing_loop(&vec_g1, &apk_vec);
+        product_c1.e == product_c2.e
+    }
+
+    pub fn aggregate_verify(apk_vec: &[APK], msg_vec: &[&[u8]], sig: &BLSSignature) -> bool {
+        if msg_vec.iter().collect::<HashSet<_>>().len() != msg_vec.len() {
+            return false;
+        };
+        Keys::core_aggregate_verify(apk_vec, msg_vec, sig)
     }
 }

--- a/src/aggregated_bls/test.rs
+++ b/src/aggregated_bls/test.rs
@@ -1,4 +1,6 @@
-use crate::aggregated_bls::party_i::Keys;
+use crate::aggregated_bls::party_i::{Keys, APK};
+use crate::basic_bls::BLSSignature;
+use curv::elliptic::curves::bls12_381::g2::GE as GE2;
 
 // test 3 out of 3
 #[test]
@@ -32,65 +34,59 @@ fn agg_sig_test_3() {
 // test batch 3 out of 3 for 3 messages
 #[test]
 fn agg_sig_test_3_batch_3() {
-    let key_vec: Vec<Vec<_>> = (0..3)
-        .map(|_| (0..3).map(|j| Keys::new(j)).collect())
-        .collect();
-
-    let pk_vec: Vec<Vec<_>> = (0..3)
-        .map(|i| (0..3).map(|j| key_vec[i][j].pk_i).collect())
-        .collect();
-
-    let apk_vec: Vec<_> = (0..3).map(|i| Keys::aggregate(&pk_vec[i])).collect();
+    let (key_vec, pk_vec, apk_vec) = keygen_batch(3, 3);
 
     let msg_vec = vec![[1].as_ref(), [2].as_ref(), [3].as_ref()];
 
-    let sig_vec: Vec<Vec<_>> = (0..3)
+    let bls_sig = sign_batch(3, &key_vec, &pk_vec, &msg_vec);
+
+    // test batch aggregation to verify as correct
+    assert_eq!(Keys::aggregate_verify(&apk_vec, &msg_vec, &bls_sig), true);
+
+    // test verification to fail a bad entry in apk_vec
+    let (_, _, bad_a_v) = keygen_batch(3, 3);
+    assert_ne!(Keys::aggregate_verify(&bad_a_v, &msg_vec, &bls_sig), true);
+
+    // test verification to fail a bad entry in msg_vec
+    let bad_m_v = vec![[4].as_ref(), [5].as_ref(), [6].as_ref()];
+    assert_ne!(Keys::aggregate_verify(&apk_vec, &bad_m_v, &bls_sig), true);
+
+    // test verification to fail a bad bls signature
+    let (bad_k_v, bad_p_v, _) = keygen_batch(3, 3);
+    let bad_b_s = sign_batch(3, &bad_k_v, &bad_p_v, &msg_vec);
+    assert_ne!(Keys::aggregate_verify(&apk_vec, &msg_vec, &bad_b_s), true);
+}
+
+fn keygen(n_parties: usize) -> (Vec<Keys>, Vec<GE2>, APK) {
+    let keys_vec: Vec<Keys> = (0..n_parties).map(|i| Keys::new(i)).collect();
+    let pk_vec: Vec<GE2> = keys_vec.iter().map(|x| x.pk_i).collect();
+    let apk = Keys::aggregate(&pk_vec);
+    (keys_vec, pk_vec, apk)
+}
+
+fn keygen_batch(n_parties: usize, m_batches: usize) -> (Vec<Vec<Keys>>, Vec<Vec<GE2>>, Vec<APK>) {
+    let keygen_vec_batch: Vec<_> = (0..m_batches).map(|_| keygen(n_parties)).collect();
+    let keys_vec_batch = keygen_vec_batch.iter().map(|x| x.0.clone()).collect();
+    let pk_vec_batch = keygen_vec_batch.iter().map(|x| x.1.clone()).collect();
+    let apk_vec_batch = keygen_vec_batch.iter().map(|x| x.2.clone()).collect();
+    (keys_vec_batch, pk_vec_batch, apk_vec_batch)
+}
+
+fn sign_batch(
+    n_parties: usize,
+    key_vec: &Vec<Vec<Keys>>,
+    pk_vec: &Vec<Vec<GE2>>,
+    msg_vec: &[&[u8]],
+) -> BLSSignature {
+    let sig_vec: Vec<Vec<_>> = (0..n_parties)
         .map(|i| {
-            (0..3)
+            (0..n_parties)
                 .map(|j| key_vec[i][j].local_sign(msg_vec[i], &pk_vec[i]))
                 .collect()
         })
         .collect();
-
-    let bls_sig_vec: Vec<_> = (0..3)
+    let bls_sig_vec: Vec<_> = (0..n_parties)
         .map(|i| Keys::combine_local_signatures(&sig_vec[i]))
         .collect();
-
-    let bls_sig_agg = Keys::aggregate_bls(&bls_sig_vec);
-
-    assert_eq!(
-        Keys::aggregate_verify(&apk_vec, &msg_vec, &bls_sig_agg),
-        true
-    );
-    assert_eq!(
-        Keys::aggregate_verify(&[apk_vec[0]; 3], &msg_vec, &bls_sig_agg),
-        false
-    );
-
-    let bad_msg_vec = vec![[4].as_ref(), [5].as_ref(), [6].as_ref()];
-    assert_eq!(
-        Keys::aggregate_verify(&apk_vec, &bad_msg_vec, &bls_sig_agg),
-        false
-    );
-    assert_eq!(
-        Keys::aggregate_verify(&apk_vec, &msg_vec, &Keys::aggregate_bls(&[bls_sig_vec[0]])),
-        false
-    );
-
-    let rep_msg_vec = vec![[1].as_ref(), [1].as_ref(), [1].as_ref()];
-    let rep_sig_vec: Vec<Vec<_>> = (0..3)
-        .map(|i| {
-            (0..3)
-                .map(|j| key_vec[i][j].local_sign(&rep_msg_vec[i], &pk_vec[i]))
-                .collect()
-        })
-        .collect();
-    let rep_bls_sig_vec: Vec<_> = (0..3)
-        .map(|i| Keys::combine_local_signatures(&rep_sig_vec[i]))
-        .collect();
-    let rep_bls_sig_agg = Keys::aggregate_bls(&rep_bls_sig_vec);
-    assert_eq!(
-        Keys::aggregate_verify(&apk_vec, &rep_msg_vec, &rep_bls_sig_agg),
-        false
-    );
+    Keys::batch_aggregate_bls(&bls_sig_vec)
 }

--- a/src/aggregated_bls/test.rs
+++ b/src/aggregated_bls/test.rs
@@ -28,3 +28,69 @@ fn agg_sig_test_3() {
     assert_ne!(bls_sig.verify(&message, &p1_keys.pk_i), true);
     assert_ne!(bls_sig.verify(&[10, 11, 12], &apk), true);
 }
+
+// test batch 3 out of 3 for 3 messages
+#[test]
+fn agg_sig_test_3_batch_3() {
+    let key_vec: Vec<Vec<_>> = (0..3)
+        .map(|_| (0..3).map(|j| Keys::new(j)).collect())
+        .collect();
+
+    let pk_vec: Vec<Vec<_>> = (0..3)
+        .map(|i| (0..3).map(|j| key_vec[i][j].pk_i).collect())
+        .collect();
+
+    let apk_vec: Vec<_> = (0..3).map(|i| Keys::aggregate(&pk_vec[i])).collect();
+
+    let msg_vec = vec![[1].as_ref(), [2].as_ref(), [3].as_ref()];
+
+    let sig_vec: Vec<Vec<_>> = (0..3)
+        .map(|i| {
+            (0..3)
+                .map(|j| key_vec[i][j].local_sign(msg_vec[i], &pk_vec[i]))
+                .collect()
+        })
+        .collect();
+
+    let bls_sig_vec: Vec<_> = (0..3)
+        .map(|i| Keys::combine_local_signatures(&sig_vec[i]))
+        .collect();
+
+    let bls_sig_agg = Keys::aggregate_bls(&bls_sig_vec);
+
+    assert_eq!(
+        Keys::aggregate_verify(&apk_vec, &msg_vec, &bls_sig_agg),
+        true
+    );
+    assert_eq!(
+        Keys::aggregate_verify(&[apk_vec[0]; 3], &msg_vec, &bls_sig_agg),
+        false
+    );
+
+    let bad_msg_vec = vec![[4].as_ref(), [5].as_ref(), [6].as_ref()];
+    assert_eq!(
+        Keys::aggregate_verify(&apk_vec, &bad_msg_vec, &bls_sig_agg),
+        false
+    );
+    assert_eq!(
+        Keys::aggregate_verify(&apk_vec, &msg_vec, &Keys::aggregate_bls(&[bls_sig_vec[0]])),
+        false
+    );
+
+    let rep_msg_vec = vec![[1].as_ref(), [1].as_ref(), [1].as_ref()];
+    let rep_sig_vec: Vec<Vec<_>> = (0..3)
+        .map(|i| {
+            (0..3)
+                .map(|j| key_vec[i][j].local_sign(&rep_msg_vec[i], &pk_vec[i]))
+                .collect()
+        })
+        .collect();
+    let rep_bls_sig_vec: Vec<_> = (0..3)
+        .map(|i| Keys::combine_local_signatures(&rep_sig_vec[i]))
+        .collect();
+    let rep_bls_sig_agg = Keys::aggregate_bls(&rep_bls_sig_vec);
+    assert_eq!(
+        Keys::aggregate_verify(&apk_vec, &rep_msg_vec, &rep_bls_sig_agg),
+        false
+    );
+}

--- a/src/threshold_bls/utilities.rs
+++ b/src/threshold_bls/utilities.rs
@@ -10,14 +10,13 @@ use curv::BigInt;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
-
-/// NIZK required for our threshold BLS: 
+/// NIZK required for our threshold BLS:
 /// This is a special case of the ec ddh proof from Curv:
 /// [https://github.com/ZenGo-X/curv/blob/master/src/cryptographic_primitives/proofs/sigma_ec_ddh.rs]
 /// In which {g1,h1} belong to G1 group and {g2,h2} belong to G2 group.
 /// This special case is possible when |G1| = |G2|. i.e the order of G1 group is equal to the order
 /// of G2 (there is a map between the groups). This is the case for BLS12-381.
-/// This is a deviation from the GLOW-BLS protocol that degrades security from strong-unforgeability 
+/// This is a deviation from the GLOW-BLS protocol that degrades security from strong-unforgeability
 /// to standard-unforgeability,as defined in "Threshold Signatures, Multisignatures and Blind Signatures Based on the Gap-Diffie-Hellman-Group Signature Scheme"
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Added `AggregateVerify` and `CoreAggregateVerify` as specified by [BLS standard](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04), together with a test case.

Maybe the `aggregate` function should be renamed as it doesn't correspond to the definition in the standard?