### PR TITLE
Update curv to v0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ pairing-plus = "0.19"
 ff-zeroize = "0.6.3"
 round-based = { version = "0.1.0", features = [] }
 thiserror = "1.0.23"
-sha2 = "0.8.0"
+sha2 = "0.9"
+old-sha2 = { package = "sha2", version = "0.8" }
 
 [dependencies.curv-kzen]
-git = "https://github.com/ZenGo-X/curv"
-branch = "ldei-improvements"
+version = "0.9"
 default-features = false
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Doron <doronz@zengo.com>", "Omer <omer@zengo.com>", "Denis <dsurv@ya
 description = "threshold BLS library"
 edition = "2018"
 
-
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
@@ -15,16 +14,16 @@ pairing-plus = "0.19"
 ff-zeroize = "0.6.3"
 round-based = { version = "0.1.0", features = [] }
 thiserror = "1.0.23"
+sha2 = "0.8.0"
 
-[dependencies.curv]
+[dependencies.curv-kzen]
 git = "https://github.com/ZenGo-X/curv"
-tag = "v0.6.2"
+branch = "ldei-improvements"
 default-features = false
 
 [dev-dependencies]
 criterion = "0.3.3"
 bls_sigs_ref = "0.3.0"
-sha2 = "0.8.0"
 round-based = { version = "0.1.0", features = ["dev"] }
 
 # Example dependencies
@@ -48,7 +47,7 @@ tonic-build = "0.4.2"
 crate-type = ["lib"]
 
 [features]
-default = ["curv/rust-gmp-kzen"]
+default = ["curv-kzen/rust-gmp-kzen"]
 # Internally used feature for testing purposes. You normally don't want to use it.
 dev = []
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    tonic_build::compile_protos("proto/mediator.proto").unwrap();
-}

--- a/src/aggregated_bls/mod.rs
+++ b/src/aggregated_bls/mod.rs
@@ -1,19 +1,17 @@
 #![allow(non_snake_case)]
 
-use curv::cryptographic_primitives::hashing::hash_sha256::HSha256;
-use curv::cryptographic_primitives::hashing::traits::Hash;
-use curv::elliptic::curves::bls12_381::g2::GE as GE2;
-use curv::elliptic::curves::traits::ECScalar;
+use curv::cryptographic_primitives::hashing::{DigestExt, Digest};
+use curv::elliptic::curves::*;
 use curv::BigInt;
+use sha2::Sha256;
 
 pub mod party_i;
 #[cfg(any(test, feature = "dev"))]
 pub mod test;
 
-pub fn h1(index: usize, pk_vec: &[GE2]) -> BigInt {
+pub fn h1(index: usize, pk_vec: &[Point<Bls12_381_2>]) -> BigInt {
     let mut pk = vec![&pk_vec[index]];
     let pk_ref_vec: Vec<_> = pk_vec.iter().map(|k| k).collect();
     pk.extend_from_slice(&pk_ref_vec[..]);
-    let result1 = HSha256::create_hash_from_ge(&pk);
-    result1.to_big_int()
+    Sha256::new().chain_points(pk).result_bigint()
 }

--- a/src/aggregated_bls/mod.rs
+++ b/src/aggregated_bls/mod.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use curv::cryptographic_primitives::hashing::{DigestExt, Digest};
+use curv::cryptographic_primitives::hashing::{Digest, DigestExt};
 use curv::elliptic::curves::*;
 use curv::BigInt;
 use sha2::Sha256;

--- a/src/aggregated_bls/mod.rs
+++ b/src/aggregated_bls/mod.rs
@@ -11,7 +11,7 @@ pub mod test;
 
 pub fn h1(index: usize, pk_vec: &[Point<Bls12_381_2>]) -> BigInt {
     let mut pk = vec![&pk_vec[index]];
-    let pk_ref_vec: Vec<_> = pk_vec.iter().map(|k| k).collect();
+    let pk_ref_vec: Vec<_> = pk_vec.iter().collect();
     pk.extend_from_slice(&pk_ref_vec[..]);
     Sha256::new().chain_points(pk).result_bigint()
 }

--- a/src/aggregated_bls/party_i.rs
+++ b/src/aggregated_bls/party_i.rs
@@ -62,12 +62,12 @@ impl Keys {
     }
 
     fn core_aggregate_verify(apk_vec: &[APK], msg_vec: &[&[u8]], sig: &BLSSignature) -> bool {
-        assert!(apk_vec.len() >= 1);
+        assert!(!apk_vec.is_empty());
         let product_c2 = Pair::compute_pairing(&sig.sigma, &Point::generator());
         let vec_g1: Vec<Point<Bls12_381_1>> = msg_vec
             .iter()
             .map(|&x| {
-                Point::from_raw(bls12_381::g1::G1Point::hash_to_curve(&x))
+                Point::from_raw(bls12_381::g1::G1Point::hash_to_curve(x))
                     .expect("hash_to_curve must return valid point")
             })
             .collect();
@@ -83,12 +83,12 @@ impl Keys {
 
     pub fn aggregate_verify(apk_vec: &[APK], msg_vec: &[&[u8]], sig: &BLSSignature) -> bool {
         assert!(apk_vec.len() == msg_vec.len());
-        if {
+        let res = {
             let mut tmp = msg_vec.to_vec();
             tmp.sort();
             tmp.dedup();
             tmp.len() != msg_vec.len()
-        } {
+        }; if res {
             return false; // verification fails if there is a repeated message
         }
         Keys::core_aggregate_verify(apk_vec, msg_vec, sig)

--- a/src/aggregated_bls/party_i.rs
+++ b/src/aggregated_bls/party_i.rs
@@ -1,32 +1,25 @@
-use curv::arithmetic::traits::Modulo;
-use curv::elliptic::curves::bls12_381::g1::FE as FE1;
-use curv::elliptic::curves::bls12_381::g1::GE as GE1;
-use curv::elliptic::curves::bls12_381::g2::FE as FE2;
-use curv::elliptic::curves::bls12_381::g2::GE as GE2;
-use curv::elliptic::curves::bls12_381::Pair;
-use curv::elliptic::curves::traits::ECPoint;
-use curv::elliptic::curves::traits::ECScalar;
-use curv::BigInt;
+use curv::elliptic::curves::*;
+use curv::elliptic::curves::bls12_381::{self, Pair};
 
 use crate::aggregated_bls::h1;
 use crate::basic_bls::BLSSignature;
 
 /// This is an implementation of BDN18 [https://eprint.iacr.org/2018/483.pdf]
 /// protocol 3.1 (MSP): pairing-based multi-signature with public-key aggregation
-#[derive(Copy, PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct Keys {
-    pub sk_i: FE2,
-    pub pk_i: GE2,
+    pub sk_i: Scalar<Bls12_381_2>,
+    pub pk_i: Point<Bls12_381_2>,
     pub party_index: usize,
 }
 
-pub type APK = GE2;
-pub type SIG = GE1;
+pub type APK = Point<Bls12_381_2>;
+pub type SIG = Point<Bls12_381_1>;
 
 impl Keys {
     pub fn new(index: usize) -> Self {
-        let u = ECScalar::new_random();
-        let y = &ECPoint::generator() * &u;
+        let u = Scalar::random();
+        let y = Point::generator() * &u;
 
         Keys {
             sk_i: u,
@@ -35,25 +28,24 @@ impl Keys {
         }
     }
 
-    pub fn aggregate(pk_vec: &[GE2]) -> APK {
-        let apk_plus_g = pk_vec.iter().fold(GE2::generator(), |acc, x| {
-            let i = pk_vec.iter().position(|y| y == x).unwrap();
-            acc + (pk_vec[i] * &ECScalar::from(&h1(i, pk_vec)))
-        });
-        apk_plus_g.sub_point(&GE2::generator().get_element())
+    pub fn aggregate(pk_vec: &[Point<Bls12_381_2>]) -> APK {
+        pk_vec.iter().enumerate()
+            .map(|(i, pk_i)| pk_i * Scalar::from_bigint(&h1(i, pk_vec)))
+            .sum()
     }
 
-    pub fn local_sign(&self, message: &[u8], pk_vec: &[GE2]) -> SIG {
-        let a_i = h1(self.party_index.clone(), pk_vec);
-        let exp = BigInt::mod_mul(&a_i, &self.sk_i.to_big_int(), &FE1::q());
-        let exp_fe1: FE1 = ECScalar::from(&exp);
-        let h_0_m = GE1::hash_to_curve(message);
-        h_0_m * exp_fe1
+    pub fn local_sign(&self, message: &[u8], pk_vec: &[Point<Bls12_381_2>]) -> SIG {
+        let a_i = Scalar::from_bigint(&h1(self.party_index, pk_vec));
+        let exp = a_i * &self.sk_i;
+        // Convert FE2 -> FE1
+        let exp = Scalar::from_raw(exp.into_raw());
+        let h_0_m = Point::from_raw(bls12_381::g1::G1Point::hash_to_curve(message))
+            .expect("hash_to_curve must return valid point");
+        h_0_m * exp
     }
 
     pub fn combine_local_signatures(sigs: &[SIG]) -> BLSSignature {
-        let (head, tail) = sigs.split_at(1);
-        let sig_sum = tail.iter().fold(head[0], |acc, x| acc + x);
+        let sig_sum = sigs.iter().sum();
         BLSSignature { sigma: sig_sum }
     }
 
@@ -62,16 +54,19 @@ impl Keys {
     }
 
     pub fn batch_aggregate_bls(sig_vec: &[BLSSignature]) -> BLSSignature {
-        let (head, tail) = sig_vec.split_at(1);
         BLSSignature {
-            sigma: tail.iter().fold(head[0].sigma, |acc, x| acc + x.sigma),
+            sigma: sig_vec.iter()
+                .map(|s| &s.sigma)
+                .sum(),
         }
     }
 
     fn core_aggregate_verify(apk_vec: &[APK], msg_vec: &[&[u8]], sig: &BLSSignature) -> bool {
         assert!(apk_vec.len() >= 1);
-        let product_c2 = Pair::compute_pairing(&sig.sigma, &GE2::generator());
-        let vec_g1: Vec<GE1> = msg_vec.iter().map(|&x| GE1::hash_to_curve(&x)).collect();
+        let product_c2 = Pair::compute_pairing(&sig.sigma, &Point::generator());
+        let vec_g1: Vec<Point<Bls12_381_1>> = msg_vec.iter().map(|&x|
+            Point::from_raw(bls12_381::g1::G1Point::hash_to_curve(&x)).expect("hash_to_curve must return valid point")
+        ).collect();
         let vec: Vec<_> = vec_g1.iter().zip(apk_vec.iter()).collect();
         let (head, tail) = vec.split_at(1);
         let product_c1 = tail

--- a/src/aggregated_bls/test.rs
+++ b/src/aggregated_bls/test.rs
@@ -94,7 +94,7 @@ pub fn agg_sig_test_n_batch_m(n: usize, msg_vec: &[&[u8]], bad_m_v: &[&[u8]]) {
 }
 
 fn keygen(n_parties: usize) -> (Vec<Keys>, Vec<Point<Bls12_381_2>>, APK) {
-    let keys_vec: Vec<Keys> = (0..n_parties).map(|i| Keys::new(i)).collect();
+    let keys_vec: Vec<Keys> = (0..n_parties).map(Keys::new).collect();
     let pk_vec: Vec<Point<Bls12_381_2>> = keys_vec.iter().map(|x| x.pk_i.clone()).collect();
     let apk = Keys::aggregate(&pk_vec);
     (keys_vec, pk_vec, apk)

--- a/src/aggregated_bls/test.rs
+++ b/src/aggregated_bls/test.rs
@@ -10,7 +10,11 @@ fn agg_sig_test_3() {
     let p3_keys = Keys::new(2);
 
     // each party broadcasts its public key pk_i
-    let pk_vec = vec![p1_keys.pk_i.clone(), p2_keys.pk_i.clone(), p3_keys.pk_i.clone()];
+    let pk_vec = vec![
+        p1_keys.pk_i.clone(),
+        p2_keys.pk_i.clone(),
+        p3_keys.pk_i.clone(),
+    ];
 
     // each party computes APK
     let apk = Keys::aggregate(&pk_vec);
@@ -60,14 +64,8 @@ pub fn test_agg_sig_3_batch_5() {
 
 #[test]
 pub fn test_agg_sig_3_batch_2() {
-    let msg_vec = vec![
-        [1].as_ref(),
-        [2].as_ref(),
-    ];
-    let bad_m_v = vec![
-        [6].as_ref(),
-        [7].as_ref(),
-    ];
+    let msg_vec = vec![[1].as_ref(), [2].as_ref()];
+    let bad_m_v = vec![[6].as_ref(), [7].as_ref()];
     agg_sig_test_n_batch_m(3, &msg_vec, &bad_m_v);
 }
 
@@ -80,31 +78,19 @@ pub fn agg_sig_test_n_batch_m(n: usize, msg_vec: &[&[u8]], bad_m_v: &[&[u8]]) {
     let bls_sig = sign_batch(n, &mkey_vec, &pk_vec, msg_vec);
 
     // test batch aggregation to verify as correct
-    assert_eq!(
-        Keys::aggregate_verify(&apk_vec, msg_vec, &bls_sig),
-        true
-    );
+    assert_eq!(Keys::aggregate_verify(&apk_vec, msg_vec, &bls_sig), true);
 
     // test verification to fail a bad entry in apk_vec
     let (_, _, bad_a_v) = keygen_batch(n, m);
-    assert_ne!(
-        Keys::aggregate_verify(&bad_a_v, msg_vec, &bls_sig),
-        true
-    );
+    assert_ne!(Keys::aggregate_verify(&bad_a_v, msg_vec, &bls_sig), true);
 
     // test verification to fail a bad entry in msg_vec
-    assert_ne!(
-        Keys::aggregate_verify(&apk_vec, bad_m_v, &bls_sig),
-        true
-    );
+    assert_ne!(Keys::aggregate_verify(&apk_vec, bad_m_v, &bls_sig), true);
 
     // test verification to fail a bad bls signature
     let (bad_k_v, bad_p_v, _) = keygen_batch(n, m);
     let bad_b_s = sign_batch(n, &bad_k_v, &bad_p_v, msg_vec);
-    assert_ne!(
-        Keys::aggregate_verify(&apk_vec, msg_vec, &bad_b_s),
-        true
-    );
+    assert_ne!(Keys::aggregate_verify(&apk_vec, msg_vec, &bad_b_s), true);
 }
 
 fn keygen(n_parties: usize) -> (Vec<Keys>, Vec<Point<Bls12_381_2>>, APK) {
@@ -114,7 +100,10 @@ fn keygen(n_parties: usize) -> (Vec<Keys>, Vec<Point<Bls12_381_2>>, APK) {
     (keys_vec, pk_vec, apk)
 }
 
-fn keygen_batch(n_parties: usize, m_batches: usize) -> (Vec<Vec<Keys>>, Vec<Vec<Point<Bls12_381_2>>>, Vec<APK>) {
+fn keygen_batch(
+    n_parties: usize,
+    m_batches: usize,
+) -> (Vec<Vec<Keys>>, Vec<Vec<Point<Bls12_381_2>>>, Vec<APK>) {
     let keygen_vec_batch: Vec<_> = (0..m_batches).map(|_| keygen(n_parties)).collect();
     let keys_vec_batch = keygen_vec_batch.iter().map(|x| x.0.clone()).collect();
     let pk_vec_batch = keygen_vec_batch.iter().map(|x| x.1.clone()).collect();

--- a/src/aggregated_bls/test.rs
+++ b/src/aggregated_bls/test.rs
@@ -1,6 +1,6 @@
 use crate::aggregated_bls::party_i::{Keys, APK};
 use crate::basic_bls::BLSSignature;
-use curv::elliptic::curves::bls12_381::g2::GE as GE2;
+use curv::elliptic::curves::*;
 
 // test 3 out of 3
 #[test]
@@ -10,7 +10,7 @@ fn agg_sig_test_3() {
     let p3_keys = Keys::new(2);
 
     // each party broadcasts its public key pk_i
-    let pk_vec = vec![p1_keys.pk_i, p2_keys.pk_i, p3_keys.pk_i];
+    let pk_vec = vec![p1_keys.pk_i.clone(), p2_keys.pk_i.clone(), p3_keys.pk_i.clone()];
 
     // each party computes APK
     let apk = Keys::aggregate(&pk_vec);
@@ -107,14 +107,14 @@ pub fn agg_sig_test_n_batch_m(n: usize, msg_vec: &[&[u8]], bad_m_v: &[&[u8]]) {
     );
 }
 
-fn keygen(n_parties: usize) -> (Vec<Keys>, Vec<GE2>, APK) {
+fn keygen(n_parties: usize) -> (Vec<Keys>, Vec<Point<Bls12_381_2>>, APK) {
     let keys_vec: Vec<Keys> = (0..n_parties).map(|i| Keys::new(i)).collect();
-    let pk_vec: Vec<GE2> = keys_vec.iter().map(|x| x.pk_i).collect();
+    let pk_vec: Vec<Point<Bls12_381_2>> = keys_vec.iter().map(|x| x.pk_i.clone()).collect();
     let apk = Keys::aggregate(&pk_vec);
     (keys_vec, pk_vec, apk)
 }
 
-fn keygen_batch(n_parties: usize, m_batches: usize) -> (Vec<Vec<Keys>>, Vec<Vec<GE2>>, Vec<APK>) {
+fn keygen_batch(n_parties: usize, m_batches: usize) -> (Vec<Vec<Keys>>, Vec<Vec<Point<Bls12_381_2>>>, Vec<APK>) {
     let keygen_vec_batch: Vec<_> = (0..m_batches).map(|_| keygen(n_parties)).collect();
     let keys_vec_batch = keygen_vec_batch.iter().map(|x| x.0.clone()).collect();
     let pk_vec_batch = keygen_vec_batch.iter().map(|x| x.1.clone()).collect();
@@ -125,7 +125,7 @@ fn keygen_batch(n_parties: usize, m_batches: usize) -> (Vec<Vec<Keys>>, Vec<Vec<
 fn sign_batch(
     n_parties: usize,
     key_vec: &Vec<Vec<Keys>>,
-    pk_vec: &Vec<Vec<GE2>>,
+    pk_vec: &Vec<Vec<Point<Bls12_381_2>>>,
     msg_vec: &[&[u8]],
 ) -> BLSSignature {
     let sig_vec: Vec<Vec<_>> = (0..msg_vec.len())

--- a/src/basic_bls.rs
+++ b/src/basic_bls.rs
@@ -1,10 +1,10 @@
 #![allow(non_snake_case)]
 
-use curv::elliptic::curves::*;
 use curv::elliptic::curves::bls12_381::{self, Pair};
+use curv::elliptic::curves::*;
 
 use ff_zeroize::Field;
-use pairing_plus::bls12_381::{Fq12};
+use pairing_plus::bls12_381::Fq12;
 
 /// Based on https://eprint.iacr.org/2018/483.pdf
 
@@ -43,7 +43,8 @@ impl BLSSignature {
     pub fn verify(&self, message: &[u8], pubkey: &Point<Bls12_381_2>) -> bool {
         let H_m = Point::from_raw(bls12_381::g1::G1Point::hash_to_curve(message))
             .expect("hash_to_curve must return valid point");
-        let product = Pair::efficient_pairing_mul(&H_m, pubkey, &self.sigma, &(-Point::generator()));
+        let product =
+            Pair::efficient_pairing_mul(&H_m, pubkey, &self.sigma, &(-Point::generator()));
         product.e == Fq12::one()
     }
 

--- a/src/threshold_bls/party_i.rs
+++ b/src/threshold_bls/party_i.rs
@@ -1,23 +1,18 @@
-use crate::Error;
+use serde::{Deserialize, Serialize};
 
 use curv::arithmetic::traits::*;
-
-use curv::elliptic::curves::traits::*;
+use curv::elliptic::curves::*;
 
 use curv::cryptographic_primitives::commitments::hash_commitment::HashCommitment;
 use curv::cryptographic_primitives::commitments::traits::Commitment;
 use curv::cryptographic_primitives::proofs::sigma_dlog::DLogProof;
 use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
+use curv::cryptographic_primitives::secret_sharing::feldman_vss::ShamirSecretSharing;
 use curv::BigInt;
 
+use crate::Error;
 use crate::basic_bls::BLSSignature;
 use crate::threshold_bls::utilities::{ECDDHProof, ECDDHStatement, ECDDHWitness};
-use curv::cryptographic_primitives::secret_sharing::feldman_vss::ShamirSecretSharing;
-use curv::elliptic::curves::bls12_381::g1::FE as FE1;
-use curv::elliptic::curves::bls12_381::g1::GE as GE1;
-use curv::elliptic::curves::bls12_381::g2::FE as FE2;
-use curv::elliptic::curves::bls12_381::g2::GE as GE2;
-use serde::{Deserialize, Serialize};
 
 const SECURITY: usize = 256;
 
@@ -34,11 +29,11 @@ const SECURITY: usize = 256;
 /// We note that the DKG can probably be biased to some extent, however, we do not find it concerning
 /// for the threshold BLS application.
 
-#[derive(Copy, PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct Keys {
-    pub u_i: FE2,
-    pub y_i: GE2,
-    pub party_index: usize,
+    pub u_i: Scalar<Bls12_381_2>,
+    pub y_i: Point<Bls12_381_2>,
+    pub party_index: u16,
 }
 
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
@@ -49,33 +44,33 @@ pub struct KeyGenComm {
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct KeyGenDecom {
     pub blind_factor: BigInt,
-    pub y_i: GE2,
+    pub y_i: Point<Bls12_381_2>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct SharedKeys {
-    pub index: usize,
+    pub index: u16,
     pub params: ShamirSecretSharing,
-    pub vk: GE2,
-    pub sk_i: FE2,
+    pub vk: Point<Bls12_381_2>,
+    pub sk_i: Scalar<Bls12_381_2>,
 }
 
 #[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
 pub struct PartialSignature {
-    pub index: usize,
-    pub sigma_i: GE1,
+    pub index: u16,
+    pub sigma_i: Point<Bls12_381_1>,
     pub ddh_proof: ECDDHProof,
 }
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Signature {
-    pub sigma: GE1,
+    pub sigma: Point<Bls12_381_1>,
 }
 
 impl Keys {
-    pub fn phase1_create(index: usize) -> Keys {
-        let u: FE2 = ECScalar::new_random();
-        let y = &ECPoint::generator() * &u;
+    pub fn phase1_create(index: u16) -> Keys {
+        let u = Scalar::random();
+        let y = Point::generator() * &u;
 
         Keys {
             u_i: u,
@@ -87,7 +82,7 @@ impl Keys {
     pub fn phase1_broadcast(&self) -> (KeyGenComm, KeyGenDecom) {
         let blind_factor = BigInt::sample(SECURITY);
         let com = HashCommitment::create_commitment_with_user_defined_randomness(
-            &(self.y_i.bytes_compressed_to_big_int() + BigInt::from(self.party_index as u32)), // we add context to the hash function
+            &(BigInt::from_bytes(&self.y_i.to_bytes(true)) + BigInt::from(self.party_index)), // we add context to the hash function
             &blind_factor,
         );
         let bcm1 = KeyGenComm { com };
@@ -103,16 +98,16 @@ impl Keys {
         params: &ShamirSecretSharing,
         decom_vec: &Vec<KeyGenDecom>,
         bc1_vec: &Vec<KeyGenComm>,
-    ) -> Result<(VerifiableSS<GE2>, Vec<FE2>, usize), Error> {
+    ) -> Result<(VerifiableSS<Bls12_381_2>, Vec<Scalar<Bls12_381_2>>, u16), Error> {
         // test length:
-        if decom_vec.len() != params.share_count || bc1_vec.len() != params.share_count {
+        if decom_vec.len() != usize::from(params.share_count) || bc1_vec.len() != usize::from(params.share_count) {
             return Err(Error::KeyGenMisMatchedVectors);
         }
         // test decommitments
         let correct_key_correct_decom_all = (0..bc1_vec.len())
             .map(|i| {
                 HashCommitment::create_commitment_with_user_defined_randomness(
-                    &(decom_vec[i].y_i.bytes_compressed_to_big_int() + BigInt::from(i as u32)),
+                    &(BigInt::from_bytes(&decom_vec[i].y_i.to_bytes(true)) + BigInt::from(i as u32)),
                     &decom_vec[i].blind_factor,
                 ) == bc1_vec[i].com
             })
@@ -122,7 +117,7 @@ impl Keys {
             VerifiableSS::share(params.threshold, params.share_count, &self.u_i);
 
         match correct_key_correct_decom_all {
-            true => Ok((vss_scheme, secret_shares, self.party_index.clone())),
+            true => Ok((vss_scheme, secret_shares.to_vec(), self.party_index)),
             false => Err(Error::KeyGenBadCommitment),
         }
     }
@@ -130,14 +125,14 @@ impl Keys {
     pub fn phase2_verify_vss_construct_keypair_prove_dlog(
         &self,
         params: &ShamirSecretSharing,
-        y_vec: &Vec<GE2>,
-        secret_shares_vec: &Vec<FE2>,
-        vss_scheme_vec: &Vec<VerifiableSS<GE2>>,
-        index: &usize,
-    ) -> Result<(SharedKeys, DLogProof<GE2>), Error> {
-        if y_vec.len() != params.share_count
-            || secret_shares_vec.len() != params.share_count
-            || vss_scheme_vec.len() != params.share_count
+        y_vec: &Vec<Point<Bls12_381_2>>,
+        secret_shares_vec: &Vec<Scalar<Bls12_381_2>>,
+        vss_scheme_vec: &Vec<VerifiableSS<Bls12_381_2>>,
+        index: u16,
+    ) -> Result<(SharedKeys, DLogProof<Bls12_381_2>), Error> {
+        if y_vec.len() != usize::from(params.share_count)
+            || secret_shares_vec.len() != usize::from(params.share_count)
+            || vss_scheme_vec.len() != usize::from(params.share_count)
         {
             return Err(Error::KeyGenMisMatchedVectors);
         }
@@ -145,7 +140,7 @@ impl Keys {
         let correct_ss_verify = (0..y_vec.len())
             .map(|i| {
                 vss_scheme_vec[i]
-                    .validate_share(&secret_shares_vec[i], *index)
+                    .validate_share(&secret_shares_vec[i], index)
                     .is_ok()
                     && vss_scheme_vec[i].commitments[0] == y_vec[i]
             })
@@ -153,9 +148,8 @@ impl Keys {
 
         match correct_ss_verify {
             true => {
-                let (head, tail) = y_vec.split_at(1);
-                let y = tail.iter().fold(head[0], |acc, x| acc + x);
-                let x_i = secret_shares_vec.iter().fold(FE2::zero(), |acc, x| acc + x);
+                let y = y_vec.iter().sum();
+                let x_i = secret_shares_vec.iter().sum();
                 let dlog_proof = DLogProof::prove(&x_i);
                 Ok((
                     SharedKeys {
@@ -173,13 +167,13 @@ impl Keys {
 
     pub fn verify_dlog_proofs(
         params: &ShamirSecretSharing,
-        dlog_proofs_vec: &[DLogProof<GE2>],
+        dlog_proofs_vec: &[DLogProof<Bls12_381_2>],
     ) -> Result<(), Error> {
-        if dlog_proofs_vec.len() != params.share_count {
+        if dlog_proofs_vec.len() != usize::from(params.share_count) {
             return Err(Error::KeyGenMisMatchedVectors);
         }
-        let xi_dlog_verify = (0..dlog_proofs_vec.len())
-            .map(|i| DLogProof::verify(&dlog_proofs_vec[i]).is_ok())
+        let xi_dlog_verify = dlog_proofs_vec.iter()
+            .map(|proof| DLogProof::verify(proof).is_ok())
             .all(|x| x);
 
         if xi_dlog_verify {
@@ -191,22 +185,22 @@ impl Keys {
 }
 
 impl SharedKeys {
-    pub fn get_shared_pubkey(&self) -> GE2 {
-        GE2::generator() * &self.sk_i
+    pub fn get_shared_pubkey(&self) -> Point<Bls12_381_2> {
+        Point::generator() * &self.sk_i
     }
 
-    pub fn partial_sign(&self, x: &[u8]) -> (PartialSignature, GE1) {
-        let H_x = GE1::hash_to_curve(x);
-        let sk_bn = ECScalar::to_big_int(&self.sk_i);
-        let sk_i_fe1: FE1 = ECScalar::from(&sk_bn);
+    pub fn partial_sign(&self, x: &[u8]) -> (PartialSignature, Point<Bls12_381_1>) {
+        let H_x = Point::from_raw(bls12_381::g1::G1Point::hash_to_curve(x)).expect("hash_to_curve must return valid point");
+        // Convert FE2 -> FE1
+        let sk_i_fe1 = Scalar::from_raw(self.sk_i.clone().into_raw());
         let sigma_i = &H_x * &sk_i_fe1;
 
-        let w = ECDDHWitness { x: sk_bn };
+        let w = ECDDHWitness { x: sk_i_fe1.to_bigint() };
 
         let delta = ECDDHStatement {
             g1: H_x.clone(),
             h1: sigma_i.clone(),
-            g2: GE2::generator(),
+            g2: Point::generator().to_point(),
             h2: self.get_shared_pubkey(),
         };
         let ddh_proof = ECDDHProof::prove(&w, &delta);
@@ -224,15 +218,15 @@ impl SharedKeys {
 
     pub fn combine(
         &self,
-        vk_vec: &[GE2],
+        vk_vec: &[Point<Bls12_381_2>],
         partial_sigs_vec: &[PartialSignature],
-        H_x: GE1,
-        s: &[usize],
+        H_x: Point<Bls12_381_1>,
+        s: &[u16],
     ) -> Result<BLSSignature, Error> {
         if vk_vec.len() != partial_sigs_vec.len()
-            || vk_vec.len() < self.params.threshold
-            || s.len() < self.params.threshold
-            || s.len() > self.params.share_count
+            || vk_vec.len() < usize::from(self.params.threshold)
+            || s.len() < usize::from(self.params.threshold)
+            || s.len() > usize::from(self.params.share_count)
         {
             return Err(Error::SigningMisMatchedVectors);
         }
@@ -243,8 +237,8 @@ impl SharedKeys {
                 let delta = ECDDHStatement {
                     g1: H_x.clone(),
                     h1: partial_sigs_vec[i].sigma_i.clone(),
-                    g2: GE2::generator(),
-                    h2: vk_vec[i],
+                    g2: Point::generator().to_point(),
+                    h2: vk_vec[i].clone(),
                 };
 
                 partial_sigs_vec[i].ddh_proof.verify(&delta)
@@ -255,19 +249,19 @@ impl SharedKeys {
         }
 
         let (head, tail) = partial_sigs_vec.split_at(1);
-        let sigma = tail[0..self.params.threshold].iter().fold(
+        let sigma = tail[0..usize::from(self.params.threshold)].iter().fold(
             &head[0].sigma_i
-                * &VerifiableSS::<GE1>::map_share_to_new_params(
+                * &VerifiableSS::<Bls12_381_1>::map_share_to_new_params(
                     &self.params,
                     head[0].index,
-                    &s[0..self.params.threshold + 1],
+                    &s[0..usize::from(self.params.threshold) + 1],
                 ),
             |acc, x| {
                 acc + &x.sigma_i
-                    * &VerifiableSS::<GE1>::map_share_to_new_params(
+                    * &VerifiableSS::<Bls12_381_1>::map_share_to_new_params(
                         &self.params,
                         x.index,
-                        &s[0..self.params.threshold + 1],
+                        &s[0..usize::from(self.params.threshold) + 1],
                     )
             },
         );

--- a/src/threshold_bls/party_i.rs
+++ b/src/threshold_bls/party_i.rs
@@ -116,7 +116,7 @@ impl Keys {
                     &decom_vec[i].blind_factor,
                 ) == bc1_vec[i].com
             })
-            .all(|x| x == true);
+            .all(|x| x);
 
         let (vss_scheme, secret_shares) =
             VerifiableSS::share(params.threshold, params.share_count, &self.u_i);
@@ -149,7 +149,7 @@ impl Keys {
                     .is_ok()
                     && vss_scheme_vec[i].commitments[0] == y_vec[i]
             })
-            .all(|x| x == true);
+            .all(|x| x);
 
         match correct_ss_verify {
             true => {
@@ -263,7 +263,7 @@ impl SharedKeys {
         let partial_sigs_verify = (0..vk_vec.len())
             .map(|i| Self::verify_partial_sig(H_x, &partial_sigs_vec[i], &vk_vec[i]))
             .all(|x| x.is_ok());
-        if partial_sigs_verify == false {
+        if !partial_sigs_verify {
             return Err(Error::PartialSignatureVerificationError);
         }
 
@@ -285,7 +285,7 @@ impl SharedKeys {
             },
         );
 
-        return Ok(BLSSignature { sigma });
+        Ok(BLSSignature { sigma })
     }
 
     // check e(H(m), vk) == e(sigma, g2)

--- a/src/threshold_bls/state_machine/keygen.rs
+++ b/src/threshold_bls/state_machine/keygen.rs
@@ -6,8 +6,7 @@ use std::time::Duration;
 
 use curv::cryptographic_primitives::proofs::sigma_dlog::DLogProof;
 use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
-use curv::elliptic::curves::bls12_381::g2::FE as FE2;
-use curv::elliptic::curves::bls12_381::g2::GE as GE2;
+use curv::elliptic::curves::*;
 use round_based::containers::{
     push::{Push, PushExt},
     *,
@@ -31,8 +30,8 @@ pub struct Keygen {
 
     msgs1: Option<Store<BroadcastMsgs<party_i::KeyGenComm>>>,
     msgs2: Option<Store<BroadcastMsgs<party_i::KeyGenDecom>>>,
-    msgs3: Option<Store<P2PMsgs<(VerifiableSS<GE2>, FE2)>>>,
-    msgs4: Option<Store<BroadcastMsgs<DLogProof<GE2>>>>,
+    msgs3: Option<Store<P2PMsgs<(VerifiableSS<Bls12_381_2>, Scalar<Bls12_381_2>)>>>,
+    msgs4: Option<Store<BroadcastMsgs<DLogProof<Bls12_381_2>>>>,
 
     msgs_queue: Vec<Msg<ProtocolMessage>>,
 
@@ -399,8 +398,8 @@ pub struct ProtocolMessage(M);
 enum M {
     Round1(party_i::KeyGenComm),
     Round2(party_i::KeyGenDecom),
-    Round3((VerifiableSS<GE2>, FE2)),
-    Round4(DLogProof<GE2>),
+    Round3((VerifiableSS<Bls12_381_2>, Scalar<Bls12_381_2>)),
+    Round4(DLogProof<Bls12_381_2>),
 }
 
 // Error

--- a/src/threshold_bls/state_machine/keygen.rs
+++ b/src/threshold_bls/state_machine/keygen.rs
@@ -31,7 +31,7 @@ pub struct Keygen {
     msgs1: Option<Store<BroadcastMsgs<party_i::KeyGenComm>>>,
     msgs2: Option<Store<BroadcastMsgs<party_i::KeyGenDecom>>>,
     msgs3: Option<Store<P2PMsgs<(VerifiableSS<Bls12_381_2>, Scalar<Bls12_381_2>)>>>,
-    msgs4: Option<Store<BroadcastMsgs<DLogProof<Bls12_381_2>>>>,
+    msgs4: Option<Store<BroadcastMsgs<DLogProof<Bls12_381_2, Sha256>>>>,
 
     msgs_queue: Vec<Msg<ProtocolMessage>>,
 
@@ -399,7 +399,7 @@ enum M {
     Round1(party_i::KeyGenComm),
     Round2(party_i::KeyGenDecom),
     Round3((VerifiableSS<Bls12_381_2>, Scalar<Bls12_381_2>)),
-    Round4(DLogProof<Bls12_381_2>),
+    Round4(DLogProof<Bls12_381_2, Sha256>),
 }
 
 // Error
@@ -455,6 +455,8 @@ impl From<InternalError> for Error {
 }
 
 use private::InternalError;
+use sha2::Sha256;
+
 mod private {
     #[derive(Debug)]
     #[non_exhaustive]

--- a/src/threshold_bls/state_machine/keygen/rounds.rs
+++ b/src/threshold_bls/state_machine/keygen/rounds.rs
@@ -106,8 +106,8 @@ impl Round2 {
         O: Push<Msg<(VerifiableSS<Bls12_381_2>, Scalar<Bls12_381_2>)>>,
     {
         let params = ShamirSecretSharing {
-            threshold: self.t.into(),
-            share_count: self.n.into(),
+            threshold: self.t,
+            share_count: self.n,
         };
         let received_decom = input.into_vec_including_me(self.decom);
         let (vss_scheme, secret_shares, index) = self
@@ -172,8 +172,8 @@ impl Round3 {
         O: Push<Msg<DLogProof<Bls12_381_2, Sha256>>>,
     {
         let params = ShamirSecretSharing {
-            threshold: self.t.into(),
-            share_count: self.n.into(),
+            threshold: self.t,
+            share_count: self.n,
         };
         let (vss_schemes, party_shares): (Vec<_>, Vec<_>) = input
             .into_vec_including_me((self.own_vss, self.own_share))
@@ -229,8 +229,8 @@ pub struct Round4 {
 impl Round4 {
     pub fn proceed(self, input: BroadcastMsgs<DLogProof<Bls12_381_2, Sha256>>) -> Result<LocalKey> {
         let params = ShamirSecretSharing {
-            threshold: self.t.into(),
-            share_count: self.n.into(),
+            threshold: self.t,
+            share_count: self.n,
         };
         let dlog_proofs = input.into_vec_including_me(self.own_dlog_proof);
         party_i::Keys::verify_dlog_proofs(&params, &dlog_proofs)
@@ -278,7 +278,7 @@ impl LocalKey {
         if n < 2 {
             return Err(InvalidLocalKey::TooFewParties { n });
         }
-        if !(1 <= t && t + 1 <= n) {
+        if !(1 <= t && t < n) {
             return Err(InvalidLocalKey::ThresholdNotInRange { t, n });
         }
         let vk_i = Point::generator() * &sk_i;

--- a/src/threshold_bls/state_machine/keygen/rounds.rs
+++ b/src/threshold_bls/state_machine/keygen/rounds.rs
@@ -7,6 +7,7 @@ use round_based::containers::push::Push;
 use round_based::containers::{self, BroadcastMsgs, P2PMsgs, Store};
 use round_based::Msg;
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 use thiserror::Error;
 
 use crate::threshold_bls::party_i;
@@ -168,7 +169,7 @@ impl Round3 {
         mut output: O,
     ) -> Result<Round4>
     where
-        O: Push<Msg<DLogProof<Bls12_381_2>>>,
+        O: Push<Msg<DLogProof<Bls12_381_2, Sha256>>>,
     {
         let params = ShamirSecretSharing {
             threshold: self.t.into(),
@@ -218,7 +219,7 @@ impl Round3 {
 
 pub struct Round4 {
     shared_keys: party_i::SharedKeys,
-    own_dlog_proof: DLogProof<Bls12_381_2>,
+    own_dlog_proof: DLogProof<Bls12_381_2, Sha256>,
 
     party_i: u16,
     t: u16,
@@ -226,7 +227,7 @@ pub struct Round4 {
 }
 
 impl Round4 {
-    pub fn proceed(self, input: BroadcastMsgs<DLogProof<Bls12_381_2>>) -> Result<LocalKey> {
+    pub fn proceed(self, input: BroadcastMsgs<DLogProof<Bls12_381_2, Sha256>>) -> Result<LocalKey> {
         let params = ShamirSecretSharing {
             threshold: self.t.into(),
             share_count: self.n.into(),
@@ -247,7 +248,10 @@ impl Round4 {
     pub fn is_expensive(&self) -> bool {
         true
     }
-    pub fn expects_messages(i: u16, n: u16) -> Store<BroadcastMsgs<DLogProof<Bls12_381_2>>> {
+    pub fn expects_messages(
+        i: u16,
+        n: u16,
+    ) -> Store<BroadcastMsgs<DLogProof<Bls12_381_2, Sha256>>> {
         containers::BroadcastMsgsStore::new(i, n)
     }
 }

--- a/src/threshold_bls/state_machine/sign.rs
+++ b/src/threshold_bls/state_machine/sign.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::mem::replace;
 use std::time::Duration;
 
-use curv::elliptic::curves::bls12_381::g1::GE as GE1;
+use curv::elliptic::curves::*;
 use round_based::containers::{
     push::{Push, PushExt},
     *,
@@ -138,7 +138,7 @@ impl Sign {
 impl StateMachine for Sign {
     type MessageBody = ProtocolMessage;
     type Err = Error;
-    type Output = (GE1, BLSSignature);
+    type Output = (Point<Bls12_381_1>, BLSSignature);
 
     fn handle_incoming(&mut self, msg: Msg<Self::MessageBody>) -> Result<()> {
         let current_round = self.current_round();
@@ -262,7 +262,7 @@ pub enum Error {
     DoublePickResult,
 
     /// Some internal assertions were failed, which is a bug
-    #[doc(hidding)]
+    #[doc(hidden)]
     #[error("internal error: {0:?}")]
     InternalError(InternalError),
 }
@@ -319,7 +319,7 @@ impl fmt::Debug for Sign {
 enum R {
     Round0(Round0),
     Round1(Round1),
-    Final((GE1, BLSSignature)),
+    Final((Point<Bls12_381_1>, BLSSignature)),
     Gone,
 }
 
@@ -367,8 +367,8 @@ mod test {
         let (_, sigs): (Vec<_>, Vec<_>) = sign_simulation.run().unwrap().into_iter().unzip();
 
         // test all signatures are equal
-        let first = sigs[0];
-        assert!(sigs.iter().all(|&item| item == first));
+        let first = &sigs[0];
+        assert!(sigs.iter().all(|item| item == first));
         // test the signatures pass verification
         assert!(parties_keys[0].shared_keys.verify(&sigs[0], msg));
 

--- a/src/threshold_bls/state_machine/sign/rounds.rs
+++ b/src/threshold_bls/state_machine/sign/rounds.rs
@@ -152,7 +152,7 @@ impl round_based::containers::MessageStore for ReceiveFirstValidPartialSigs {
         if !valid {
             return Err(ReceivedPartialSigNotValid::InvalidPartialSig);
         }
-        if self.msgs.iter().find(|(i, _)| *i == msg.body.0).is_some() {
+        if self.msgs.iter().any(|(i, _)| *i == msg.body.0) {
             return Err(ReceivedPartialSigNotValid::ShareOverwrite);
         }
 

--- a/src/threshold_bls/state_machine/sign/rounds.rs
+++ b/src/threshold_bls/state_machine/sign/rounds.rs
@@ -1,11 +1,14 @@
+use std::collections::HashSet;
+use std::convert::TryFrom;
+
 use curv::elliptic::curves::*;
 use round_based::containers::push::Push;
-use round_based::containers::{self, BroadcastMsgs, Store};
 use round_based::Msg;
 use thiserror::Error;
 
 use crate::basic_bls::BLSSignature;
 use crate::threshold_bls::party_i;
+use crate::threshold_bls::party_i::SharedKeys;
 use crate::threshold_bls::state_machine::keygen::LocalKey;
 
 pub struct Round0 {
@@ -48,11 +51,11 @@ pub struct Round1 {
 impl Round1 {
     pub fn proceed(
         self,
-        input: BroadcastMsgs<(u16, party_i::PartialSignature)>,
+        input: Vec<(u16, party_i::PartialSignature)>,
     ) -> Result<(Point<Bls12_381_1>, BLSSignature)> {
         let (indexes, sigs): (Vec<_>, Vec<_>) = input
-            .into_vec_including_me((self.key.i, self.partial_sig))
             .into_iter()
+            .chain(Some((self.key.i, self.partial_sig)))
             .unzip();
 
         let mut vk_vec = vec![];
@@ -70,7 +73,7 @@ impl Round1 {
         let sig = self
             .key
             .shared_keys
-            .combine(&vk_vec, &sigs, self.message.clone(), &indexes)
+            .combine(&vk_vec, &sigs, &self.message, &indexes)
             .map_err(ProceedError::PartialSignatureVerification)?;
         Ok((self.message, sig))
     }
@@ -80,8 +83,107 @@ impl Round1 {
     pub fn expects_messages(
         i: u16,
         n: u16,
-    ) -> Store<BroadcastMsgs<(u16, party_i::PartialSignature)>> {
-        containers::BroadcastMsgsStore::new(i, n)
+        local_kay: &LocalKey,
+        message_to_sign: Point<Bls12_381_1>,
+    ) -> ReceiveFirstValidPartialSigs {
+        ReceiveFirstValidPartialSigs {
+            msgs: vec![],
+            received_from: Default::default(),
+
+            i,
+            H_x: message_to_sign,
+            vk_vec: local_kay.vk_vec.clone(),
+            signers_n: n,
+            secret_holders: local_kay.n,
+            threshold: local_kay.t,
+        }
+    }
+}
+
+pub struct ReceiveFirstValidPartialSigs {
+    msgs: Vec<(u16, party_i::PartialSignature)>,
+    received_from: HashSet<u16>,
+
+    i: u16,
+    H_x: Point<Bls12_381_1>,
+    vk_vec: Vec<Point<Bls12_381_2>>,
+    signers_n: u16,
+    secret_holders: u16,
+    threshold: u16,
+}
+
+impl ReceiveFirstValidPartialSigs {
+    pub fn messages_received(&self) -> usize {
+        self.msgs.len()
+    }
+
+    pub fn messages_total(&self) -> u16 {
+        self.threshold
+    }
+}
+
+impl round_based::containers::MessageStore for ReceiveFirstValidPartialSigs {
+    type M = (u16, party_i::PartialSignature);
+    type Err = ReceivedPartialSigNotValid;
+    type Output = Vec<(u16, party_i::PartialSignature)>;
+
+    fn push_msg(&mut self, msg: Msg<Self::M>) -> Result<(), Self::Err> {
+        if msg.sender == self.i {
+            return Err(ReceivedPartialSigNotValid::ReceivedMyOwnShare);
+        } else if msg.receiver.is_some() {
+            return Err(ReceivedPartialSigNotValid::ExpectedBroadcast);
+        } else if self.received_from.contains(&msg.sender) {
+            return Err(ReceivedPartialSigNotValid::MsgOverwrite);
+        } else if !(1 <= msg.body.0 && msg.body.0 <= self.secret_holders) {
+            return Err(ReceivedPartialSigNotValid::PartyOriginalIndexOutOfRange {
+                i: msg.body.0,
+                n: self.secret_holders,
+            });
+        } else if !self.wants_more() {
+            return Err(ReceivedPartialSigNotValid::TooManyMsgs);
+        }
+
+        let valid = SharedKeys::verify_partial_sig(
+            &self.H_x,
+            &msg.body.1,
+            &self.vk_vec[usize::from(msg.body.0) - 1],
+        )
+        .is_ok();
+        if !valid {
+            return Err(ReceivedPartialSigNotValid::InvalidPartialSig);
+        }
+        if self.msgs.iter().find(|(i, _)| *i == msg.body.0).is_some() {
+            return Err(ReceivedPartialSigNotValid::ShareOverwrite);
+        }
+
+        self.msgs.push(msg.body);
+        self.received_from.insert(msg.sender);
+
+        Ok(())
+    }
+
+    fn contains_msg_from(&self, sender: u16) -> bool {
+        self.received_from.contains(&sender)
+    }
+
+    fn wants_more(&self) -> bool {
+        self.msgs.len() < usize::from(self.threshold)
+    }
+
+    fn finish(self) -> Result<Self::Output, Self::Err> {
+        if !self.wants_more() {
+            Ok(self.msgs)
+        } else {
+            Err(ReceivedPartialSigNotValid::NotEnoughMsgs)
+        }
+    }
+
+    fn blame(&self) -> (u16, Vec<u16>) {
+        let left = u16::try_from(self.msgs.len()).unwrap() - self.threshold - 1;
+        let didnt_send_message = (1..=self.signers_n)
+            .filter(|i| !self.received_from.contains(i))
+            .collect();
+        (left, didnt_send_message)
     }
 }
 
@@ -103,4 +205,24 @@ pub enum ProceedError {
     PartialSignatureVerification(crate::Error),
 }
 
-type Result<T> = std::result::Result<T, ProceedError>;
+#[derive(Debug, Error)]
+pub enum ReceivedPartialSigNotValid {
+    #[error("expected broadcast message, received p2p")]
+    ExpectedBroadcast,
+    #[error("received msg from the same sender twice")]
+    MsgOverwrite,
+    #[error("received the same signature share twice")]
+    ShareOverwrite,
+    #[error("party index out of range i={i}, n={n}")]
+    PartyOriginalIndexOutOfRange { i: u16, n: u16 },
+    #[error("partial sig proof is not valid")]
+    InvalidPartialSig,
+    #[error("not enough messages received to finish the protocol")]
+    NotEnoughMsgs,
+    #[error("enough messages received to construct a signature")]
+    TooManyMsgs,
+    #[error("received message from myself")]
+    ReceivedMyOwnShare,
+}
+
+type Result<T, E = ProceedError> = std::result::Result<T, E>;

--- a/src/threshold_bls/test.rs
+++ b/src/threshold_bls/test.rs
@@ -210,7 +210,7 @@ fn another_bls_impl_validates_signature() {
     // Verify signature
     let cs = &[1u8];
     let valid =
-        BLSSigCore::<ExpandMsgXmd<sha2::Sha256>>::core_verify(public_key, signature, message, cs);
+        BLSSigCore::<ExpandMsgXmd<old_sha2::Sha256>>::core_verify(public_key, signature, message, cs);
     assert!(valid);
 }
 
@@ -222,17 +222,17 @@ fn we_recognize_signatures_generated_by_ref_impl() {
     use pairing_plus::hash_to_field::ExpandMsgXmd;
 
     // Keygen
-    let (secret_key, public_key) = <G1 as BLSSigCore<ExpandMsgXmd<sha2::Sha256>>>::keygen(b"123");
+    let (secret_key, public_key) = <G1 as BLSSigCore<ExpandMsgXmd<old_sha2::Sha256>>>::keygen(b"123");
 
     // Sign message
     let message = b"KZen";
     let cs = &[1u8];
     let signature: G1 =
-        BLSSigCore::<ExpandMsgXmd<sha2::Sha256>>::core_sign(secret_key, message, cs);
+        BLSSigCore::<ExpandMsgXmd<old_sha2::Sha256>>::core_sign(secret_key, message, cs);
 
     // Verify signature
     let valid =
-        BLSSigCore::<ExpandMsgXmd<sha2::Sha256>>::core_verify(public_key, signature, message, cs);
+        BLSSigCore::<ExpandMsgXmd<old_sha2::Sha256>>::core_verify(public_key, signature, message, cs);
     assert!(valid);
 
     // Now check that our primitive `BLSSignature` also successfully verifies signature

--- a/src/threshold_bls/test.rs
+++ b/src/threshold_bls/test.rs
@@ -59,7 +59,9 @@ pub fn keygen_t_n_parties(t: u16, n: u16) -> (Vec<SharedKeys>, Vec<Point<Bls12_3
     let (bc1_vec, decom_vec): (Vec<_>, Vec<_>) =
         party_keys_vec.iter().map(|k| k.phase1_broadcast()).unzip();
 
-    let y_vec = (0..n).map(|i| decom_vec[usize::from(i)].y_i.clone()).collect::<Vec<Point<Bls12_381_2>>>();
+    let y_vec = (0..n)
+        .map(|i| decom_vec[usize::from(i)].y_i.clone())
+        .collect::<Vec<Point<Bls12_381_2>>>();
 
     let mut vss_scheme_vec = Vec::new();
     let mut secret_shares_vec = Vec::new();
@@ -106,7 +108,9 @@ pub fn keygen_t_n_parties(t: u16, n: u16) -> (Vec<SharedKeys>, Vec<Point<Bls12_3
         dlog_proof_vec.push(dlog_proof);
     }
 
-    let vk_vec = (0..n).map(|i| dlog_proof_vec[usize::from(i)].pk.clone()).collect::<Vec<Point<Bls12_381_2>>>();
+    let vk_vec = (0..n)
+        .map(|i| dlog_proof_vec[usize::from(i)].pk.clone())
+        .collect::<Vec<Point<Bls12_381_2>>>();
 
     //all parties run:
     Keys::verify_dlog_proofs(&parames, &dlog_proof_vec).expect("");
@@ -156,7 +160,7 @@ pub fn sign(
             k.combine(
                 &vk_participating_parties[..],
                 &partial_sign_vec[..],
-                H_x[0].clone(),
+                &H_x[0],
                 s,
             )
             .expect("")
@@ -186,8 +190,12 @@ fn another_bls_impl_validates_signature() {
     let keygen = keygen_t_n_parties(1, 2);
     let public_key = &keygen.0[0].vk;
     let mut public_key_bytes = vec![];
-    G2Affine::serialize(public_key.as_raw().underlying_ref(), &mut public_key_bytes, true)
-        .expect("serialize to vec should always succeed");
+    G2Affine::serialize(
+        public_key.as_raw().underlying_ref(),
+        &mut public_key_bytes,
+        true,
+    )
+    .expect("serialize to vec should always succeed");
 
     // Sign message
     let message = b"KZen";
@@ -228,8 +236,14 @@ fn we_recognize_signatures_generated_by_ref_impl() {
     assert!(valid);
 
     // Now check that our primitive `BLSSignature` also successfully verifies signature
-    let public_key = Point::from_raw(bls12_381::g2::G2Point::from_underlying(public_key.into_affine())).unwrap();
-    let sigma = Point::from_raw(bls12_381::g1::G1Point::from_underlying(signature.into_affine())).unwrap();
+    let public_key = Point::from_raw(bls12_381::g2::G2Point::from_underlying(
+        public_key.into_affine(),
+    ))
+    .unwrap();
+    let sigma = Point::from_raw(bls12_381::g1::G1Point::from_underlying(
+        signature.into_affine(),
+    ))
+    .unwrap();
     let signature = BLSSignature { sigma };
     let valid = signature.verify(message, &public_key);
     assert!(valid);

--- a/src/threshold_bls/test.rs
+++ b/src/threshold_bls/test.rs
@@ -209,8 +209,9 @@ fn another_bls_impl_validates_signature() {
 
     // Verify signature
     let cs = &[1u8];
-    let valid =
-        BLSSigCore::<ExpandMsgXmd<old_sha2::Sha256>>::core_verify(public_key, signature, message, cs);
+    let valid = BLSSigCore::<ExpandMsgXmd<old_sha2::Sha256>>::core_verify(
+        public_key, signature, message, cs,
+    );
     assert!(valid);
 }
 
@@ -222,7 +223,8 @@ fn we_recognize_signatures_generated_by_ref_impl() {
     use pairing_plus::hash_to_field::ExpandMsgXmd;
 
     // Keygen
-    let (secret_key, public_key) = <G1 as BLSSigCore<ExpandMsgXmd<old_sha2::Sha256>>>::keygen(b"123");
+    let (secret_key, public_key) =
+        <G1 as BLSSigCore<ExpandMsgXmd<old_sha2::Sha256>>>::keygen(b"123");
 
     // Sign message
     let message = b"KZen";
@@ -231,8 +233,9 @@ fn we_recognize_signatures_generated_by_ref_impl() {
         BLSSigCore::<ExpandMsgXmd<old_sha2::Sha256>>::core_sign(secret_key, message, cs);
 
     // Verify signature
-    let valid =
-        BLSSigCore::<ExpandMsgXmd<old_sha2::Sha256>>::core_verify(public_key, signature, message, cs);
+    let valid = BLSSigCore::<ExpandMsgXmd<old_sha2::Sha256>>::core_verify(
+        public_key, signature, message, cs,
+    );
     assert!(valid);
 
     // Now check that our primitive `BLSSignature` also successfully verifies signature

--- a/src/threshold_bls/test.rs
+++ b/src/threshold_bls/test.rs
@@ -2,9 +2,7 @@ use crate::basic_bls::BLSSignature;
 use crate::threshold_bls::party_i::Keys;
 use crate::threshold_bls::party_i::SharedKeys;
 use curv::cryptographic_primitives::secret_sharing::feldman_vss::ShamirSecretSharing;
-use curv::elliptic::curves::bls12_381::g2::FE;
-use curv::elliptic::curves::bls12_381::{g1::GE as GE1, g2::GE as GE2};
-use curv::elliptic::curves::traits::{ECPoint, ECScalar};
+use curv::elliptic::curves::*;
 use pairing_plus::CurveProjective;
 
 #[test]
@@ -20,16 +18,16 @@ fn test_keygen_t2_n3() {
 // 2 out of 2
 #[test]
 fn test_sign_n2_t1_tprime2() {
-    let message = vec![100, 101, 102, 103];
-    let signatories: Vec<usize> = vec![0, 1];
+    let message = [100, 101, 102, 103];
+    let signatories = [0, 1];
     sign(&message[..], 1, 2, &signatories[..], None);
 }
 
 // 3 out of 3
 #[test]
 fn test_sign_n3_t2_tprime3() {
-    let message = vec![100, 101, 102, 103];
-    let signatories: Vec<usize> = vec![0, 1, 2];
+    let message = [100, 101, 102, 103];
+    let signatories = [0, 1, 2];
     sign(&message[..], 2, 3, &signatories[..], None);
 }
 
@@ -37,19 +35,19 @@ fn test_sign_n3_t2_tprime3() {
 #[test]
 fn test_sign_n5_t2_tprime4() {
     let message = [100, 101, 102, 103];
-    let signatories: Vec<usize> = vec![0, 2, 3, 4];
+    let signatories = [0, 2, 3, 4];
     sign(&message[..], 2, 5, &signatories[..], None);
 }
 
 // 5 out of 8 with 6 signatories
 #[test]
 fn test_sign_n8_t4_tprime6() {
-    let message = vec![100, 101, 102, 103];
-    let signatories: Vec<usize> = vec![0, 1, 2, 4, 6, 7];
+    let message = [100, 101, 102, 103];
+    let signatories = [0, 1, 2, 4, 6, 7];
     sign(&message[..], 4, 8, &signatories[..], None);
 }
 
-pub fn keygen_t_n_parties(t: usize, n: usize) -> (Vec<SharedKeys>, Vec<GE2>) {
+pub fn keygen_t_n_parties(t: u16, n: u16) -> (Vec<SharedKeys>, Vec<Point<Bls12_381_2>>) {
     let parames = ShamirSecretSharing {
         threshold: t,
         share_count: n,
@@ -61,7 +59,7 @@ pub fn keygen_t_n_parties(t: usize, n: usize) -> (Vec<SharedKeys>, Vec<GE2>) {
     let (bc1_vec, decom_vec): (Vec<_>, Vec<_>) =
         party_keys_vec.iter().map(|k| k.phase1_broadcast()).unzip();
 
-    let y_vec = (0..n).map(|i| decom_vec[i].y_i).collect::<Vec<GE2>>();
+    let y_vec = (0..n).map(|i| decom_vec[usize::from(i)].y_i.clone()).collect::<Vec<Point<Bls12_381_2>>>();
 
     let mut vss_scheme_vec = Vec::new();
     let mut secret_shares_vec = Vec::new();
@@ -85,12 +83,12 @@ pub fn keygen_t_n_parties(t: usize, n: usize) -> (Vec<SharedKeys>, Vec<GE2>) {
         .map(|i| {
             (0..n)
                 .map(|j| {
-                    let vec_j = &secret_shares_vec[j];
-                    vec_j[i]
+                    let vec_j = &secret_shares_vec[usize::from(j)];
+                    vec_j[usize::from(i)].clone()
                 })
-                .collect::<Vec<FE>>()
+                .collect::<Vec<Scalar<Bls12_381_2>>>()
         })
-        .collect::<Vec<Vec<FE>>>();
+        .collect::<Vec<Vec<Scalar<Bls12_381_2>>>>();
 
     let mut shared_keys_vec = Vec::new();
     let mut dlog_proof_vec = Vec::new();
@@ -101,26 +99,26 @@ pub fn keygen_t_n_parties(t: usize, n: usize) -> (Vec<SharedKeys>, Vec<GE2>) {
                 &y_vec,
                 &party_shares[i],
                 &vss_scheme_vec,
-                &(index_vec[i] + 1),
+                index_vec[i] + 1,
             )
             .expect("");
         shared_keys_vec.push(shared_keys);
         dlog_proof_vec.push(dlog_proof);
     }
 
-    let vk_vec = (0..n).map(|i| dlog_proof_vec[i].pk).collect::<Vec<GE2>>();
+    let vk_vec = (0..n).map(|i| dlog_proof_vec[usize::from(i)].pk.clone()).collect::<Vec<Point<Bls12_381_2>>>();
 
     //all parties run:
     Keys::verify_dlog_proofs(&parames, &dlog_proof_vec).expect("");
 
     //test
     let xi_vec = (0..=t)
-        .map(|i| shared_keys_vec[i].sk_i)
-        .collect::<Vec<FE>>();
+        .map(|i| shared_keys_vec[usize::from(i)].sk_i.clone())
+        .collect::<Vec<Scalar<Bls12_381_2>>>();
     let x = vss_scheme_vec[0]
         .clone()
-        .reconstruct(&index_vec[0..=t], &xi_vec);
-    let sum_u_i = party_keys_vec.iter().fold(FE::zero(), |acc, x| acc + x.u_i);
+        .reconstruct(&index_vec[0..=usize::from(t)], &xi_vec);
+    let sum_u_i: Scalar<Bls12_381_2> = party_keys_vec.iter().map(|k| &k.u_i).sum();
     assert_eq!(x, sum_u_i);
 
     (shared_keys_vec, vk_vec)
@@ -128,10 +126,10 @@ pub fn keygen_t_n_parties(t: usize, n: usize) -> (Vec<SharedKeys>, Vec<GE2>) {
 
 pub fn sign(
     message: &[u8],
-    t: usize,
-    n: usize,
-    s: &[usize],
-    keygen: Option<(Vec<SharedKeys>, Vec<GE2>)>,
+    t: u16,
+    n: u16,
+    s: &[u16],
+    keygen: Option<(Vec<SharedKeys>, Vec<Point<Bls12_381_2>>)>,
 ) -> BLSSignature {
     // run keygen
     let (shared_keys_vec, vk_vec) = keygen.unwrap_or_else(|| keygen_t_n_parties(t, n));
@@ -139,11 +137,11 @@ pub fn sign(
     let t_prime = s.len();
     //carry on signing with shared keys of indices from s
     let shared_keys_participating_parties = (0..t_prime as usize)
-        .map(|i| shared_keys_vec[s[i]].clone())
+        .map(|i| shared_keys_vec[usize::from(s[i])].clone())
         .collect::<Vec<SharedKeys>>();
     let vk_participating_parties = (0..t_prime as usize)
-        .map(|i| vk_vec[s[i]].clone())
-        .collect::<Vec<GE2>>();
+        .map(|i| vk_vec[usize::from(s[i])].clone())
+        .collect::<Vec<Point<Bls12_381_2>>>();
 
     // each party performs a partial sign
     let (partial_sign_vec, H_x): (Vec<_>, Vec<_>) = shared_keys_participating_parties
@@ -158,7 +156,7 @@ pub fn sign(
             k.combine(
                 &vk_participating_parties[..],
                 &partial_sign_vec[..],
-                H_x[0],
+                H_x[0].clone(),
                 s,
             )
             .expect("")
@@ -166,12 +164,12 @@ pub fn sign(
         .collect::<Vec<BLSSignature>>();
 
     // test all signatures are equal
-    let first = bls_sig_vec[0];
-    assert!(bls_sig_vec.iter().all(|&item| item == first));
+    let first = &bls_sig_vec[0];
+    assert!(bls_sig_vec.iter().all(|item| item == first));
     // test the signatures pass verification
     assert!(shared_keys_vec[0].verify(&bls_sig_vec[0], message));
 
-    bls_sig_vec[0]
+    bls_sig_vec[0].clone()
 }
 
 #[cfg(test)]
@@ -186,9 +184,9 @@ fn another_bls_impl_validates_signature() {
 
     // Run keygen
     let keygen = keygen_t_n_parties(1, 2);
-    let public_key = keygen.0[0].vk.clone();
+    let public_key = &keygen.0[0].vk;
     let mut public_key_bytes = vec![];
-    G2Affine::serialize(&public_key.get_element(), &mut public_key_bytes, true)
+    G2Affine::serialize(public_key.as_raw().underlying_ref(), &mut public_key_bytes, true)
         .expect("serialize to vec should always succeed");
 
     // Sign message
@@ -230,8 +228,8 @@ fn we_recognize_signatures_generated_by_ref_impl() {
     assert!(valid);
 
     // Now check that our primitive `BLSSignature` also successfully verifies signature
-    let public_key = GE2::from(public_key.into_affine());
-    let sigma = GE1::from(signature.into_affine());
+    let public_key = Point::from_raw(bls12_381::g2::G2Point::from_underlying(public_key.into_affine())).unwrap();
+    let sigma = Point::from_raw(bls12_381::g1::G1Point::from_underlying(signature.into_affine())).unwrap();
     let signature = BLSSignature { sigma };
     let valid = signature.verify(message, &public_key);
     assert!(valid);

--- a/src/threshold_bls/test.rs
+++ b/src/threshold_bls/test.rs
@@ -53,7 +53,7 @@ pub fn keygen_t_n_parties(t: u16, n: u16) -> (Vec<SharedKeys>, Vec<Point<Bls12_3
         share_count: n,
     };
     let party_keys_vec = (0..n)
-        .map(|i| Keys::phase1_create(i))
+        .map(Keys::phase1_create)
         .collect::<Vec<Keys>>();
 
     let (bc1_vec, decom_vec): (Vec<_>, Vec<_>) =

--- a/src/threshold_bls/utilities.rs
+++ b/src/threshold_bls/utilities.rs
@@ -1,14 +1,10 @@
-use curv::cryptographic_primitives::hashing::hash_sha256::HSha256;
-use curv::cryptographic_primitives::hashing::traits::Hash;
-use curv::elliptic::curves::bls12_381::g1::FE as FE1;
-use curv::elliptic::curves::bls12_381::g1::GE as GE1;
-use curv::elliptic::curves::bls12_381::g2::FE as FE2;
-use curv::elliptic::curves::bls12_381::g2::GE as GE2;
-use curv::elliptic::curves::traits::ECPoint;
-use curv::elliptic::curves::traits::ECScalar;
-use curv::BigInt;
 use serde::{Deserialize, Serialize};
-use zeroize::Zeroize;
+
+use sha2::Sha256;
+
+use curv::cryptographic_primitives::hashing::{Digest, DigestExt};
+use curv::elliptic::curves::*;
+use curv::BigInt;
 
 /// NIZK required for our threshold BLS:
 /// This is a special case of the ec ddh proof from Curv:
@@ -21,17 +17,17 @@ use zeroize::Zeroize;
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct ECDDHProof {
-    pub a1: GE1,
-    pub a2: GE2,
+    pub a1: Point<Bls12_381_1>,
+    pub a2: Point<Bls12_381_2>,
     pub z: BigInt,
 }
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct ECDDHStatement {
-    pub g1: GE1,
-    pub h1: GE1,
-    pub g2: GE2,
-    pub h2: GE2,
+    pub g1: Point<Bls12_381_1>,
+    pub h1: Point<Bls12_381_1>,
+    pub g2: Point<Bls12_381_2>,
+    pub h2: Point<Bls12_381_2>,
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -41,76 +37,84 @@ pub struct ECDDHWitness {
 
 impl ECDDHProof {
     pub fn prove(w: &ECDDHWitness, delta: &ECDDHStatement) -> ECDDHProof {
-        let mut s1 = FE1::new_random();
+        let s1 = Scalar::random();
         let a1 = &delta.g1 * &s1;
-        let s = s1.to_big_int();
-        let mut s2: FE2 = ECScalar::from(&s);
+        // Convert FE1 -> FE2
+        let s2 = Scalar::from_raw(s1.into_raw());
         let a2 = &delta.g2 * &s2;
-        let e = HSha256::create_hash(&[
-            &delta.g1.bytes_compressed_to_big_int(),
-            &delta.h1.bytes_compressed_to_big_int(),
-            &delta.g2.bytes_compressed_to_big_int(),
-            &delta.h2.bytes_compressed_to_big_int(),
-            &a1.bytes_compressed_to_big_int(),
-            &a2.bytes_compressed_to_big_int(),
-        ]);
-        let z = s + e * &w.x;
-        s1.zeroize();
-        s2.zeroize();
+        let e = Sha256::new()
+            .chain_points([
+                &delta.g1,
+                &delta.h1,
+            ])
+            .chain_points([
+                &delta.g2,
+                &delta.h2,
+            ])
+            .chain_point(&a1)
+            .chain_point(&a2)
+            .result_bigint();
+        let z = s2.to_bigint() + e * &w.x;
         ECDDHProof { a1, a2, z }
     }
 
     pub fn verify(&self, delta: &ECDDHStatement) -> bool {
-        let e = HSha256::create_hash(&[
-            &delta.g1.bytes_compressed_to_big_int(),
-            &delta.h1.bytes_compressed_to_big_int(),
-            &delta.g2.bytes_compressed_to_big_int(),
-            &delta.h2.bytes_compressed_to_big_int(),
-            &self.a1.bytes_compressed_to_big_int(),
-            &self.a2.bytes_compressed_to_big_int(),
-        ]);
-        let z_g1 = &delta.g1 * &ECScalar::from(&self.z);
-        let z_g2 = &delta.g2 * &ECScalar::from(&self.z);
+        let e = Sha256::new()
+            .chain_points([
+                &delta.g1,
+                &delta.h1,
+            ])
+            .chain_points([
+                &delta.g2,
+                &delta.h2,
+            ])
+            .chain_point(&self.a1)
+            .chain_point(&self.a2)
+            .result_bigint();
+        let z_g1 = &delta.g1 * Scalar::from_bigint(&self.z);
+        let z_g2 = &delta.g2 * Scalar::from_bigint(&self.z);
 
-        let a1_plus_e_h1 = &self.a1 + &(&delta.h1 * &ECScalar::from(&e));
-        let a2_plus_e_h2 = &self.a2 + &(&delta.h2 * &ECScalar::from(&e));
+        let a1_plus_e_h1 = &self.a1 + &(&delta.h1 * Scalar::from_bigint(&e));
+        let a2_plus_e_h2 = &self.a2 + &(&delta.h2 * Scalar::from_bigint(&e));
         z_g1 == a1_plus_e_h1 && z_g2 == a2_plus_e_h2
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use curv::elliptic::curves::*;
+
     use super::*;
-    use curv::elliptic::curves::bls12_381::g1::FE as FE1;
-    use curv::elliptic::curves::traits::{ECPoint, ECScalar};
-    use curv::arithmetic::traits::*;
 
     #[test]
     fn test_ecddh_proof() {
-        let x = FE1::new_random().to_big_int();
-        let g1 = ECPoint::generator();
-        let g2 = ECPoint::base_point2();
-        let h1 = &g1 * &ECScalar::from(&x);
-        let h2 = &g2 * &ECScalar::from(&x);
+        let x1 = Scalar::random();
+        let x2 = Scalar::from_raw(x1.clone().into_raw());
 
-        let delta = ECDDHStatement { g1, h1, g2, h2 };
-        let w = ECDDHWitness { x };
+        let g1 = Point::generator();
+        let g2 = Point::base_point2();
+        let h1 = g1 * &x1;
+        let h2 = g2 * &x2;
+
+        let delta = ECDDHStatement { g1: g1.to_point(), h1, g2: g2.clone(), h2 };
+        let w = ECDDHWitness { x: x1.to_bigint() };
         let proof = ECDDHProof::prove(&w, &delta);
         assert!(proof.verify(&delta));
     }
 
     #[test]
-    #[should_panic]
     fn test_bad_ecddh_proof() {
-        let x = FE1::new_random().to_big_int();
-        let g1 = ECPoint::generator();
-        let g2 = ECPoint::base_point2();
-        let h1 = &g1 * &ECScalar::from(&x);
-        let h2 = &g2 * &ECScalar::from(&(&x + BigInt::one()));
+        let x1 = Scalar::random();
+        let x2 = Scalar::from_raw(x1.clone().into_raw());
 
-        let delta = ECDDHStatement { g1, h1, g2, h2 };
-        let w = ECDDHWitness { x };
+        let g1 = Point::generator();
+        let g2 = Point::base_point2();
+        let h1 = g1 * &x1;
+        let h2 = g2 * (&x2 + Scalar::from(1));
+
+        let delta = ECDDHStatement { g1: g1.to_point(), h1, g2: g2.clone(), h2 };
+        let w = ECDDHWitness { x: x1.to_bigint() };
         let proof = ECDDHProof::prove(&w, &delta);
-        assert!(proof.verify(&delta));
+        assert!(!proof.verify(&delta));
     }
 }

--- a/src/threshold_bls/utilities.rs
+++ b/src/threshold_bls/utilities.rs
@@ -43,14 +43,8 @@ impl ECDDHProof {
         let s2 = Scalar::from_raw(s1.into_raw());
         let a2 = &delta.g2 * &s2;
         let e = Sha256::new()
-            .chain_points([
-                &delta.g1,
-                &delta.h1,
-            ])
-            .chain_points([
-                &delta.g2,
-                &delta.h2,
-            ])
+            .chain_points([&delta.g1, &delta.h1])
+            .chain_points([&delta.g2, &delta.h2])
             .chain_point(&a1)
             .chain_point(&a2)
             .result_bigint();
@@ -60,14 +54,8 @@ impl ECDDHProof {
 
     pub fn verify(&self, delta: &ECDDHStatement) -> bool {
         let e = Sha256::new()
-            .chain_points([
-                &delta.g1,
-                &delta.h1,
-            ])
-            .chain_points([
-                &delta.g2,
-                &delta.h2,
-            ])
+            .chain_points([&delta.g1, &delta.h1])
+            .chain_points([&delta.g2, &delta.h2])
             .chain_point(&self.a1)
             .chain_point(&self.a2)
             .result_bigint();
@@ -96,7 +84,12 @@ mod tests {
         let h1 = g1 * &x1;
         let h2 = g2 * &x2;
 
-        let delta = ECDDHStatement { g1: g1.to_point(), h1, g2: g2.clone(), h2 };
+        let delta = ECDDHStatement {
+            g1: g1.to_point(),
+            h1,
+            g2: g2.clone(),
+            h2,
+        };
         let w = ECDDHWitness { x: x1.to_bigint() };
         let proof = ECDDHProof::prove(&w, &delta);
         assert!(proof.verify(&delta));
@@ -112,7 +105,12 @@ mod tests {
         let h1 = g1 * &x1;
         let h2 = g2 * (&x2 + Scalar::from(1));
 
-        let delta = ECDDHStatement { g1: g1.to_point(), h1, g2: g2.clone(), h2 };
+        let delta = ECDDHStatement {
+            g1: g1.to_point(),
+            h1,
+            g2: g2.clone(),
+            h2,
+        };
         let w = ECDDHWitness { x: x1.to_bigint() };
         let proof = ECDDHProof::prove(&w, &delta);
         assert!(!proof.verify(&delta));


### PR DESCRIPTION
- Updates curv to the latest version
- Adds a constructor for LocalKey struct (needed for random-beacon)
- Optimise signing. The party used to await receiving all `n` messages, now the party outputs a signature once it receives `t+1` valid partial signatures
- Fix clippy warnings